### PR TITLE
Fix/no word splitting

### DIFF
--- a/pages/me/received/[email].tsx
+++ b/pages/me/received/[email].tsx
@@ -50,13 +50,13 @@ export default function MyCommendations({ comms }: InferGetStaticPropsType<typeo
           <Typography className={raleway.className} fontSize={30} fontWeight={900} mt={2} mb={1.25} align="center">Received Commendations</Typography>
           {comms.map((comm, i) =>
             <Paper key={i} sx={{ mb: 2, mx: "auto", maxWidth: "44rem", p: 2, backgroundColor: grey[200], borderRadius: "18px" }}>
-              <Box sx={{ display: "flex", flexDirection: "row" }} minHeight="6.5rem">
+              <Box sx={{ display: "flex", flexDirection: "row"}} minHeight="6.5rem">
                 <Avatar>
                   <Image fill src={comm.sender.imageURL ?? stinger.src} alt={comm.sender.name} />
                 </Avatar>
                 <Stack ml={2}>
                   <Typography fontWeight="bold">{comm.sender.name}</Typography>
-                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "break-all" }}>{comm.message}</Typography>
+                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "normal" }}>{comm.message}</Typography>
                 </Stack>
               </Box>
             </Paper>)}

--- a/pages/me/received/[email].tsx
+++ b/pages/me/received/[email].tsx
@@ -50,13 +50,13 @@ export default function MyCommendations({ comms }: InferGetStaticPropsType<typeo
           <Typography className={raleway.className} fontSize={30} fontWeight={900} mt={2} mb={1.25} align="center">Received Commendations</Typography>
           {comms.map((comm, i) =>
             <Paper key={i} sx={{ mb: 2, mx: "auto", maxWidth: "44rem", p: 2, backgroundColor: grey[200], borderRadius: "18px" }}>
-              <Box sx={{ display: "flex", flexDirection: "row"}} minHeight="6.5rem">
+              <Box sx={{ display: "flex", flexDirection: "row" }} minHeight="6.5rem">
                 <Avatar>
                   <Image fill src={comm.sender.imageURL ?? stinger.src} alt={comm.sender.name} />
                 </Avatar>
                 <Stack ml={2}>
                   <Typography fontWeight="bold">{comm.sender.name}</Typography>
-                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "normal" }}>{comm.message}</Typography>
+                  <Typography fontSize="0.9rem" sx={{ wordWrap: "normal", wordBreak: "break-word" }}>{comm.message}</Typography>
                 </Stack>
               </Box>
             </Paper>)}

--- a/pages/me/sent/[email].tsx
+++ b/pages/me/sent/[email].tsx
@@ -56,7 +56,7 @@ export default function MyCommendations({ comms }: InferGetStaticPropsType<typeo
                 </Avatar>
                 <Stack ml={2}>
                   <Typography fontWeight="bold">{comm.recipient.name}</Typography>
-                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "normal" }}>{comm.message}</Typography>
+                  <Typography fontSize="0.9rem" sx={{ wordWrap: "normal", wordBreak: "break-word" }}>{comm.message}</Typography>
                 </Stack>
               </Box>
             </Paper>)}

--- a/pages/me/sent/[email].tsx
+++ b/pages/me/sent/[email].tsx
@@ -56,7 +56,7 @@ export default function MyCommendations({ comms }: InferGetStaticPropsType<typeo
                 </Avatar>
                 <Stack ml={2}>
                   <Typography fontWeight="bold">{comm.recipient.name}</Typography>
-                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "break-all" }}>{comm.message}</Typography>
+                  <Typography fontSize="0.9rem" sx={{ wordWrap: "break-word", wordBreak: "normal" }}>{comm.message}</Typography>
                 </Stack>
               </Box>
             </Paper>)}


### PR DESCRIPTION
Closes #173 This combination of tags { wordWrap: "normal", wordBreak: "break-word" } should prevent words from being broken across lines unless the word takes more space than the entirety of a single line can provide.