### PR TITLE
Auth options for stg

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -45,7 +45,7 @@ const stgOptions: AuthOptions = {
           where: {
             email: credentials.email
           }
-        })
+        });
         if (user) {
           return user;
         } else {


### PR DESCRIPTION
Closes #191. This makes the Credentials provider work on staging. Make sure to have Doppler on `stg` and use your normal Cedarville email to log in. Currently, it looks at our `dev` database, so it'll give you everything you would normally see in dev.